### PR TITLE
chore: bump socket.io and socket.io-client to v4.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "jquery": "^3.7.1",
     "noty": "^3.2.0-beta",
     "popper.js": "^1.16.1",
-    "socket.io": "^2.5.4",
-    "socket.io-client": "^2.5.4"
+    "socket.io": "^4.8.1",
+    "socket.io-client": "^4.8.1"
   }
 }


### PR DESCRIPTION
### Motivation
- Corriger des alertes de sécurité liées aux dépendances temps réel en mettant à jour `socket.io` et `socket.io-client` vers une version plus récente et supportée.

### Description
- Mis à jour de `package.json` pour remplacer `"socket.io": "^2.5.4"` et `"socket.io-client": "^2.5.4"` par `"^4.8.1"` et commit des modifications.

### Testing
- Vérification locale via `node -e "const p=require('./package.json'); console.log(p.dependencies['socket.io'], p.dependencies['socket.io-client']);"` a confirmé les nouvelles versions; `npm audit` n'a pas pu être exécuté car il n'y a pas de `package-lock.json`; la tentative de générer un lockfile avec `npm i --package-lock-only` a échoué en environnement CI en raison d'un `403 Forbidden` lors de la récupération d'un paquet du registre npm.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995c9c25500833285e2eebd19d3916e)